### PR TITLE
Use set_enabled() and set_disabled() instead

### DIFF
--- a/usr/lib/whonixsetup_/ft_m_1
+++ b/usr/lib/whonixsetup_/ft_m_1
@@ -75,63 +75,12 @@ if [ ! "$exit_code" = "0" ]; then
    exit 0
 fi
 
-if [ ! -f /usr/local/etc/torrc.d/40_anon_connection_wizard.conf ]; then
-   mkdir -p /usr/local/etc/torrc.d
-   echo "#DisableNetwork 0" > /usr/local/etc/torrc.d/40_anon_connection_wizard.conf
-fi
 
-## Check if Tor was already enabled.
-## This is to prevent getting ed from failing.
-already_commented_in="0"
-while read -r LINE; do
-   if [ "$LINE" = 'DisableNetwork 0' ]; then
-      already_commented_in="1"
-      dialog --title "whonixsetup - Success!" --msgbox 'Tor networking should already be enabled.
-
-Note: whonixsetup enables Tor networking by adding "DisableNetwork 0" to /usr/local/etc/torrc.d/40_anon_connection_wizard.conf. There is no need to this multiple times, and it is probably not the cause of network problems. You can manually check if "DisableNetwork 0" is in /usr/local/etc/torrc.d/40_anon_connection_wizard.conf.
-
-Press Enter to restart Tor and check its status.
-' 640 480
-      break
-   fi
-done < "/usr/local/etc/torrc.d/40_anon_connection_wizard.conf"
-
-if [ "$already_commented_in" = "0" ]; then
-   ## Comment in DisableNetwork 0 in /usr/local/etc/torrc.d/40_anon_connection_wizard.conf.
-   exit_code="0"
-   ed -s /usr/local/etc/torrc.d/40_anon_connection_wizard.conf <<< $',s/\#DisableNetwork 0/DisableNetwork 0/g\nw' || { exit_code="$?" ; true; };
-
-   ## Ensure changes get written to the disk right now.
-   sync
-
-   if [ ! "$exit_code" = "0" ]; then
-      TITLE="whonixsetup - Info"
-
-      MSG='
-Could not add "DisableNetwork 0" to /usr/local/etc/torrc.d/40_anon_connection_wizard.conf.
-
-Press Enter to restart Tor and check its status.
-'
-
-   else
-      TITLE="whonixsetup - Info"
-
-      MSG="
-Tor networking has been enabled in /usr/local/etc/torrc.d/40_anon_connection_wizard.conf.
-
-Press Enter to restart Tor and check its status.
-"
-   fi
-
-   dialog --title "$TITLE" --msgbox "$MSG" 640 480
-fi
-
-service_action="restart"
-exit_code="0"
-systemctl --no-pager "$service_action" tor@default >/dev/null || { exit_code="$?" ; true; };
-sync
-sleep 1
-tor_action_exit_code_check
+## set_enabled() function will:
+## 1. create 40_anon_connection_wizard.conf if it was missing
+## 2. set final value of DisableNetwork in the file to 0
+## 3. restart Tor using systemd
+python3 -c 'from anon_connection_wizard import tor_status; tor_status.set_enabled()' >/dev/null 2>&1
 
 exit_code="0"
 service_action="status"

--- a/usr/lib/whonixsetup_/ft_m_1
+++ b/usr/lib/whonixsetup_/ft_m_1
@@ -80,25 +80,54 @@ fi
 ## 1. create 40_anon_connection_wizard.conf if it was missing
 ## 2. set final value of DisableNetwork in the file to 0
 ## 3. restart Tor using systemd
-python3 -c 'from anon_connection_wizard import tor_status; tor_status.set_enabled()' >/dev/null 2>&1 || { exit_code="$?" ; true; };
 
-if [ "$exit_code" = "0" ]; then
-    TITLE="whonixsetup - Success!"
 
+error_msg="$(python3 -c 'from anon_connection_wizard import tor_status; tor_status.set_enabled()' 2>&1)" || { exit_code="$?" ; true; };
+
+if [ "$exit_code" != "0" ]; then
+    TITLE="whonixsetup - Error!"
     MSG="
+python3 -c 'from anon_connection_wizard import tor_status; tor_status.set_enabled()'
+returned exit code $exit_code, which means failed to enable Tor.
+
+Error messages are as follows:
+$error_msg
+
+If some dependencies are missing (for example, cannot import name 'tor_status'):
+    sudo apt-get install anon-connection-wizard
+
+If there is something wrong with your Tor config, you can open /usr/local/etc/torrc.d/50_user.conf in the terminal:
+    sudo nano /usr/local/etc/torrc.d/50_user.conf
+
+Or, if you are using a graphical Whonix-Gateway:
+    Start Menu -> Applications -> Tor Config File
+
+Useful troubleshooting commands:
+
+    sudo service tor@default restart
+
+Or for more detailed Tor config report:
+    sudo --non-interactive /usr/bin/tor --defaults-torrc /usr/share/tor/tor-service-defaults-torrc -f /etc/tor/torrc --RunAsDaemon 0 --verify-config
+"
+    dialog --title "$TITLE" --msgbox "$MSG" 640 480
+    true "INFO: Ok, exit 1, so whonixsetup will end."
+    exit 1
+fi
+
+TITLE="whonixsetup - Success!"
+MSG="
 Tor has been successfully enabled.
 
 Press Enter to run whonixcheck and exit.
 "
-    dialog --title "$TITLE" --msgbox "$MSG" 640 480
-else
-    exit_code="0"
-    service_action="status"
-    systemctl --no-pager "$service_action" tor@default || { exit_code="$?" ; true; };
-    sync
-    sleep 1
-    tor_action_exit_code_check
-fi
+dialog --title "$TITLE" --msgbox "$MSG" 640 480
+
+# exit_code="0"
+# service_action="status"
+# systemctl --no-pager "$service_action" tor@default || { exit_code="$?" ; true; };
+# sync
+# sleep 1
+# tor_action_exit_code_check
 
 ## Start whonixcheck.
 exit_code="0"

--- a/usr/lib/whonixsetup_/ft_m_1
+++ b/usr/lib/whonixsetup_/ft_m_1
@@ -80,24 +80,25 @@ fi
 ## 1. create 40_anon_connection_wizard.conf if it was missing
 ## 2. set final value of DisableNetwork in the file to 0
 ## 3. restart Tor using systemd
-python3 -c 'from anon_connection_wizard import tor_status; tor_status.set_enabled()' >/dev/null 2>&1
+python3 -c 'from anon_connection_wizard import tor_status; tor_status.set_enabled()' >/dev/null 2>&1 || { exit_code="$?" ; true; };
 
-exit_code="0"
-service_action="status"
-systemctl --no-pager "$service_action" tor@default || { exit_code="$?" ; true; };
-sync
-sleep 1
-tor_action_exit_code_check
+if [ "$exit_code" = "0" ]; then
+    TITLE="whonixsetup - Success!"
 
-TITLE="whonixsetup - Success!"
-
-MSG="
-Tor was successfully restarted.
+    MSG="
+Tor has been successfully enabled.
 
 Press Enter to run whonixcheck and exit.
 "
-
-dialog --title "$TITLE" --msgbox "$MSG" 640 480
+    dialog --title "$TITLE" --msgbox "$MSG" 640 480
+else
+    exit_code="0"
+    service_action="status"
+    systemctl --no-pager "$service_action" tor@default || { exit_code="$?" ; true; };
+    sync
+    sleep 1
+    tor_action_exit_code_check
+fi
 
 ## Start whonixcheck.
 exit_code="0"

--- a/usr/lib/whonixsetup_/ft_m_2
+++ b/usr/lib/whonixsetup_/ft_m_2
@@ -70,14 +70,14 @@ if [ "$exit_code" = "0" ]; then
    true "INFO: Ok, exit 1, so whonixsetup will end."
    dialog --title "whonixsetup - Success!" --msgbox 'Tor networking has been disabled.
 
-Note: whonixsetup disables Tor networking by using the tor_disabled() function in tor_status.py in anon_connection_wizard package
+Note: whonixsetup disables Tor networking by writing "DisableNetwork 1" to /usr/local/etc/torrc.d/40_anon_connection_wizard.conf
 ' 640 480
    ## Signal for whonixsetup to break the while loop.
    exit 1
 else
    dialog --title "whonixsetup - ERROR!" --msgbox 'Tor networking could not be disabled. Please report this bug!
 
-Note: whonixsetup disables Tor networking by using the tor_disabled() function in tor_status.py in anon_connection_wizard package
+Note: whonixsetup tried to disable Tor networking by writing "DisableNetwork 1" to /usr/local/etc/torrc.d/40_anon_connection_wizard.conf but was unable to
 ' 640 480
 
    dialog --title "whonixsetup - WARNING" --msgbox 'Trying to stop the Tor process...

--- a/usr/lib/whonixsetup_/ft_m_2
+++ b/usr/lib/whonixsetup_/ft_m_2
@@ -60,52 +60,24 @@ if [ ! "$exit_code" = "0" ]; then
    exit 0
 fi
 
-## Check if Tor networking was already disabled.
-## This is to prevent getting a /usr/local/etc/torrc.d/40_anon_connection_wizard.conf
-## with ####DisableNetwork 0 if the user chooses
-## this option multiple times.
-while read -r LINE; do
-   if [ "$LINE" = "#DisableNetwork 0" ]; then
-      dialog --title "Success!" --msgbox '"DisableNetwork 0" was already in /usr/local/etc/torrc.d/40_anon_connection_wizard.conf
-
-Tor networking should already be disabled, and there is no need to disable it multiple times.
-' 640 480
-
-      dialog --title "whonixsetup - Info" --msgbox 'Checking if the Tor process is still running and stopping it if necessary...' 640 480
-
-      stop_tor
-      true "INFO: Ok, exit 1, so whonixsetup will end."
-      ## Signal for whonixsetup to break the while loop.
-      exit 1
-   fi
-done < "/usr/local/etc/torrc.d/40_anon_connection_wizard.conf"
-
-dialog --title "Info" --msgbox 'Trying to disable Tor networking...
-
-Note: This will comment out "DisableNetwork 0" in /usr/local/etc/torrc.d/40_anon_connection_wizard.conf
-' 640 480
-
-## Comment out DisableNetwork 0 in /usr/local/etc/torrc.d/40_anon_connection_wizard.conf.
-exit_code="0"
-ed -s /usr/local/etc/torrc.d/40_anon_connection_wizard.conf <<< $',s/DisableNetwork 0/#DisableNetwork 0/g\nw' || { exit_code="$?"; true; };
-
-## Ensure changes get written to the disk right now.
-sync
+## set_disabled() function will:
+## 1. create 40_anon_connection_wizard.conf if it was missing
+## 2. set final value of DisableNetwork in the file to 1
+## 3. stop Tor using systemd
+python3 -c 'from anon_connection_wizard import tor_status; tor_status.set_disabled()' >/dev/null 2>&1  || { exit_code="$?" ; true; };
 
 if [ "$exit_code" = "0" ]; then
-   stop_tor
    true "INFO: Ok, exit 1, so whonixsetup will end."
-   ## Signal for whonixsetup to break the while loop.
-   exit 1
-
    dialog --title "whonixsetup - Success!" --msgbox 'Tor networking has been disabled.
 
-Note: whonixsetup disables Tor networking by commenting "DisableNetwork 0" in /usr/local/etc/torrc.d/40_anon_connection_wizard.conf
+Note: whonixsetup disables Tor networking by using the tor_disabled() function in tor_status.py in anon_connection_wizard package
 ' 640 480
+   ## Signal for whonixsetup to break the while loop.
+   exit 1
 else
    dialog --title "whonixsetup - ERROR!" --msgbox 'Tor networking could not be disabled. Please report this bug!
 
-Note: whonixsetup tried to disable Tor networking by commenting "DisableNetwork 0" in /usr/local/etc/torrc.d/40_anon_connection_wizard.conf but was unable to.
+Note: whonixsetup disables Tor networking by using the tor_disabled() function in tor_status.py in anon_connection_wizard package
 ' 640 480
 
    dialog --title "whonixsetup - WARNING" --msgbox 'Trying to stop the Tor process...


### PR DESCRIPTION
When parsing the torrc file, we switch from command line flavor to using the python functions availabed in anon_connection_wizard package.

The advantages are as follows:

1. Better consistency with anon_connection_wizard style parsing

While the command line flavor parsing comments (out) `#DisableNetwork 0`, anon_connection_wizard writes `DisableNetwork 0` or `DisableNetwork 1` to 40_connection_wizard.conf . This can be a issue when user uses both anon-connection-wizard and whonixsetup for at least once. Using the same implementation will aviod the inconsistency.

2. More robust in handling different cases

Considering the inconsistency descriped above, the command line flavor parsing was not robust enough. For example, it will assume the final value in anon_connection_wizard.conf is 0 right after it sees a `DisableNetwork 0` line. This will ignore the case where there is also a `DisableNetwork 1` line after it.

3. Lower maintanance cost

It allows us to only maintance one piece of code.

4. Simplified the logic in the bash script

The disadvantages are as follows:

1. anon-connection-wizard becomes a dependency of whonixsetup now

However, since whonixsetup should be installed in both Whonox-Gateway and Whonox-Workstation, but anon-connection-wizard should NOT be installed in Whonix-Worksatation, we cannot claim the dependency in Debian control.

2. Less error info in CLI

The error happens in the python function may not be well-reflected to the CLI which is seen by user. For example, user may only know the attempt to enable Tor failed, but does not know if the problem is because of the missing of anon_connection_wizard package or anything else.